### PR TITLE
Ensure echo repo inherits user identity

### DIFF
--- a/git-echo
+++ b/git-echo
@@ -92,6 +92,21 @@ sync_core_config() {
   done
 }
 
+sync_identity_config() {
+  resolve_paths
+
+  local key value
+  for key in user.name user.email; do
+    if echo_git config --get "$key" >/dev/null 2>&1; then
+      continue
+    fi
+
+    if value=$(git -C "$REPO_ROOT" config --get "$key" 2>/dev/null); then
+      echo_git config "$key" "$value"
+    fi
+  done
+}
+
 refresh_ignore_rules() {
   resolve_paths
   local exclude_dir="$ECHO_GIT_DIR/info"
@@ -226,6 +241,7 @@ handle_init() {
   echo_git config core.bare false
   echo_git symbolic-ref HEAD refs/heads/echo >/dev/null
   sync_core_config
+  sync_identity_config
   refresh_ignore_rules
   update_main_exclude_rules
 
@@ -267,6 +283,7 @@ handle_add() {
 handle_commit() {
   ensure_echo_exists
   maybe_refresh_ignore_rules
+  sync_identity_config
   if echo_git commit "$@"; then
     update_main_exclude_rules
   else


### PR DESCRIPTION
## Summary
- add a helper that populates the echo repository's user.name and user.email from the parent repository
- invoke the helper during init and commit so commits can run without additional configuration

## Testing
- ./tests/run.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9837c18188321ac0cdcbb3121e8e2